### PR TITLE
increase memoryLimitsBytes to 2g

### DIFF
--- a/.codenvy.json
+++ b/.codenvy.json
@@ -16,7 +16,7 @@
             ],
             "servers": {},
             "attributes": {
-              "memoryLimitsBytes": "1073741824"
+              "memoryLimitsBytes": "2147483648"
             }
           }
         }


### PR DESCRIPTION
to avoid workspace crashes `memoryLimitsBytes` should be at least 2gb

@amrecio please take a look